### PR TITLE
Fix device selection for CPU-only DDP

### DIFF
--- a/src/gnn_bench/ddp_utils.py
+++ b/src/gnn_bench/ddp_utils.py
@@ -19,7 +19,8 @@ def setup_ddp(args):
         rank=args.rank,
         world_size=args.world_size
     )
-    torch.cuda.set_device(args.local_rank)
+    if torch.cuda.is_available() and not getattr(args, "no_cuda", False):
+        torch.cuda.set_device(args.local_rank)
 
 
 def cleanup_ddp():


### PR DESCRIPTION
## Summary
- avoid unconditional `torch.cuda.set_device` call in `setup_ddp`

## Testing
- `python -m py_compile src/gnn_bench/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841fb67c0808325b773a49fd8811ad4