### PR TITLE
Fix CUDA seeding on CPU-only systems

### DIFF
--- a/src/gnn_bench/train.py
+++ b/src/gnn_bench/train.py
@@ -69,7 +69,8 @@ def set_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
 
 def load_dataset(name: str):


### PR DESCRIPTION
## Summary
- avoid CUDA seed calls when CUDA is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842016a1b4c83258c42b361515881f9