### PR TITLE
Rename --plots CLI option to --report

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ experiments:
 ### Running Experiments
 
 ```bash
-# Run all experiments defined in a YAML config, then plot:
-gnn_bench_run --config config/gat_ogbn_arxiv.yaml --plots
+# Run all experiments defined in a YAML config, then generate a report:
+gnn_bench_run --config config/gat_ogbn_arxiv.yaml --report
 ```
 
 - **`--config`** (or `-c`) points to your YAML file. If omitted, defaults to `config/default.yaml`.
-- **`--plots`** tells the script to run the plotting step after all experiments finish.
+- **`--report`** tells the script to generate the Markdown report (with plots) after all experiments finish.
 - **`--sort-by`** controls sorting in the Markdown report (default = `date`). Options: `date`, `acc`, `throughput`.
 
 Each experiment in the YAML file expands into one (or more) runs. For each run you’ll see:
@@ -294,9 +294,9 @@ experiments:
    source setup.sh install cpu
    ```
 
-2. **Run GAT on OGBN-Arxiv**  
+2. **Run GAT on OGBN-Arxiv**
    ```bash
-   gnn_bench_run --config config/gat_ogbn_arxiv.yaml --plots
+   gnn_bench_run --config config/gat_ogbn_arxiv.yaml --report
    ```
 
 3. **Inspect Results**

--- a/src/gnn_bench/cli.py
+++ b/src/gnn_bench/cli.py
@@ -24,8 +24,8 @@ def _run_entry():
         help="Path to YAML config file defining experiments. Default: config/default.yaml"
     )
     parser.add_argument(
-        "--plots", action="store_true",
-        help="After experiments complete, run the plotting step."
+        "--report", action="store_true",
+        help="After experiments complete, generate the Markdown report with plots."
     )
     parser.add_argument(
         "--sort-by", choices=["date", "acc", "throughput"], default="date",
@@ -180,9 +180,9 @@ def _run_entry():
             for ns in sp_tasks:
                 _run_single(ns)
 
-    # After all experiments, optionally call plotting
-    if args.plots and last_results_db is not None:
-        print(f"\n▶ Generating plots for: {last_results_db}")
+    # After all experiments, optionally generate the report
+    if args.report and last_results_db is not None:
+        print(f"\n▶ Generating report for: {last_results_db}")
         try:
             plot_main(
                 db_path=last_results_db,


### PR DESCRIPTION
## Summary
- rename `--plots` CLI flag to `--report`
- update report generation message
- document `--report` usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c27768088325b76e44a65b6f5c73