### PR TITLE
Refactor report generation and timestamp handling

### DIFF
--- a/results.md
+++ b/results.md
@@ -1,0 +1,58 @@
+# Experiment Results
+
+## Config Overview
+```yaml
+# config/default.yaml
+#
+
+experiments:
+  # “smoke‐tests”
+  - experiment_name: "smoke_test_cpu"
+    dataset: "Cora"
+    model: "gcn"
+    epochs: 5
+    batch_size: [16, 32, 64, 128, 256, 512]
+    lr: 0.001
+    hidden_dim: 64
+    seed: 42
+    world_size: 1
+    no_cuda: true
+
+  - experiment_name: "smoke_test_gpu"
+    dataset: "Cora"
+    model: "gcn"
+    epochs: 5
+    batch_size: [16, 32, 64, 128, 256, 512]
+    lr: 0.001
+    hidden_dim: 64
+    seed: 42
+    world_size: 1
+    no_cuda: false
+```
+
+## smoke_test_cpu
+**Different config:** no_cuda=true
+
+| Batch Size | Val Acc | Throughput |
+|:----------:|:-------:|:----------:|
+| 16 | - | - |
+| 32 | - | - |
+| 64 | - | - |
+| 128 | - | - |
+| 256 | - | - |
+| 512 | - | - |
+
+## smoke_test_gpu
+**Different config:** no_cuda=false
+
+| Batch Size | Val Acc | Throughput |
+|:----------:|:-------:|:----------:|
+| 16 | - | - |
+| 32 | - | - |
+| 64 | - | - |
+| 128 | - | - |
+| 256 | - | - |
+| 512 | - | - |
+
+## Experiment Metadata from the Database
+_No runs recorded yet._

--- a/src/gnn_bench/cli.py
+++ b/src/gnn_bench/cli.py
@@ -188,7 +188,8 @@ def _run_entry():
                 db_path=last_results_db,
                 output_dir=os.path.dirname(last_results_db),
                 overwrite=True,
-                sort_by=args.sort_by
+                sort_by=args.sort_by,
+                config_path=config_path,
             )
         except Exception:
             traceback.print_exc()
@@ -207,3 +208,20 @@ def run_entry():
     except Exception:
         traceback.print_exc()
         sys.exit(1)
+
+
+def plot_entry():
+    """Entry point for the standalone plotting CLI."""
+    parser = argparse.ArgumentParser(description="Generate Markdown report from a results database")
+    parser.add_argument("--db", dest="db_path", required=True, help="Path to results.db")
+    parser.add_argument("--output-dir", required=True, help="Directory to write plots and Markdown")
+    parser.add_argument("--sort-by", choices=["date", "acc", "throughput"], default="date")
+    parser.add_argument("--config", dest="config_path", help="YAML config for experiment definitions")
+    args = parser.parse_args()
+    plot_main(
+        db_path=args.db_path,
+        output_dir=args.output_dir,
+        overwrite=True,
+        sort_by=args.sort_by,
+        config_path=args.config_path,
+    )

--- a/src/gnn_bench/db_logger.py
+++ b/src/gnn_bench/db_logger.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import threading
+from datetime import datetime
 from typing import Dict, Any
 
 _LOCK = threading.Lock()
@@ -74,6 +75,7 @@ class DBLogger:
             # Timeout for waiting on database locks in concurrent scenarios
             conn = sqlite3.connect(self.db_path, timeout=30)
             c = conn.cursor()
+            timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
             c.execute("""
                 INSERT INTO runs (
                     experiment_name,
@@ -90,8 +92,9 @@ class DBLogger:
                     final_val_loss,
                     final_val_acc,
                     total_train_time,
-                    throughput
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                    throughput,
+                    timestamp
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """, (
                 params["experiment_name"],
                 params["dataset"],
@@ -108,6 +111,7 @@ class DBLogger:
                 metrics["final_val_acc"],
                 metrics["total_train_time"],
                 metrics["throughput"],
+                timestamp,
             ))
             conn.commit()
             conn.close()


### PR DESCRIPTION
## Summary
- fix database timestamps by logging explicit timezone-aware time
- pass config path to plotting and implement standalone `plot_entry`
- restructure plotting logic to include config overview and per-experiment sections
- add example `results.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842c39d48888325b51f849e90a41863